### PR TITLE
Mooc exercises

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -115,7 +115,11 @@
       "origin": "duckietown/gym-duckietown",
       "dts_args": {
           "-C": "docker/AIDO1/server-python3"
-      },
-      "base": "pytorch"
-  } 
+      }
+  }, 
+  {
+      "name": "challenge-aido_LF-simulator-gym",
+      "origin": "duckietown/challenge-aido_LF-simulator-gym",
+      "base": "duckietown/gym-duckietown-server-python3:daffy-aido4"
+  }
 ]

--- a/repositories.json
+++ b/repositories.json
@@ -99,7 +99,7 @@
       "name": "aido3-base-python3",
       "origin": "duckietown/aido-protocols",
       "dts-args": {
-          "-C": "minimal-nodes-stubs/aido3-bas-python3"
+          "-C": "minimal-nodes-stubs/aido3-base-python3"
       }
   },
   {
@@ -109,5 +109,13 @@
           "-C": "3_submit"
       },
       "base": "challenge-aido_LF-template-ros"
-  }  
+  }, 
+  {
+      "name": "gym-duckietown",
+      "origin": "duckietown/gym-duckietown",
+      "dts_args": {
+          "-C": "docker/AIDO1/server-python3"
+      },
+      "base": "pytorch"
+  } 
 ]


### PR DESCRIPTION
Added 2 repos for which I will need images for mooc-exercises (plus fixed a typo ?)

* Gym-duckietown was not yet in jenkins, added it to build the defualt daffy image
* challenge-aido_LF-simulator-gym was also not yet in jenkins, and daffy is a new branch so the image will be new.

I would like to have images for non-default branches (i.e. id like to have my mooc-exercises branches for these repos) that would have automatically built images at some point