### PR TITLE
Add acquisition bridge

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -120,5 +120,10 @@
         "name": "dt-duckiebot-fifos-bridge",
         "origin": "duckietown/dt-duckiebot-fifos-bridge",
         "base": "dt-ros-commons"
+    },
+    {
+        "name": "acquisition-bridge",
+        "origin": "duckietown/acquisition-bridge",
+        "base": "dt-ros-commons"
     }
 ]


### PR DESCRIPTION
Seems like the acquisition bridge was missing from CI. Was there any reason for that ?